### PR TITLE
Caching dependencies in actions build test (linux)

### DIFF
--- a/.github/workflows/build-gfortran-linux.yml
+++ b/.github/workflows/build-gfortran-linux.yml
@@ -55,9 +55,10 @@ jobs:
     # - name: install sprng2
     #   run: sudo apt-get install libsprng2
 
+    # Cache dependencies for mcfost to avoid downloading/installing them each time this workflow runs
     - name: cache dependencies
       id: cache-deps
-      uses: john-shaffer/cache@main     # Need this to unpack the cache tar with sudo
+      uses: john-shaffer/cache@main     # Need this version to unpack the cache tar with sudo
       env:
         cache-name: cache-mcfost-dependencies
       with:
@@ -78,6 +79,7 @@ jobs:
     #        gcc --version
     #        gfortran --version
 
+    # Only do this (lengthy) setup if dependency cache not found
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: prepare mcfost environment
       run: |

--- a/.github/workflows/build-gfortran-linux.yml
+++ b/.github/workflows/build-gfortran-linux.yml
@@ -55,33 +55,16 @@ jobs:
     # - name: install sprng2
     #   run: sudo apt-get install libsprng2
 
-    # - name: cache dependencies
-    #   id: cache-deps
-    #   uses: john-shaffer/cache@main     # Need this to unpack the cache tar with sudo
-    #   env:
-    #     cache-name: cache-mcfost-dependencies
-    #   with:
-    #     path: |
-    #       /usr/local/Cellar/gcc/13.1.0
-    #       /usr/local/Cellar/hdf5/1.14.1
-    #       /usr/local/Cellar/cfitsio/4.3.0
-    #       /usr/local/Cellar/voro-dev/0.4.6+
-    #       /usr/local/Cellar/sprng2/2.0
-    #     key: ${{ runner.os }}-build-${{ env.cache-name }}
-
-    #   # Restoring the brew installs from cache doesn't put files where mcfost expects
-    #   # Manually create symlinks so the compiler can find everything
-    # - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
-    #   name: add symbolic links if cache exists
-    #   run: |
-    #     ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
-    #     ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
-    #     ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
-    #     ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
-    #     ln -s /usr/local/Cellar/voro-dev/0.4.6+/lib/libvoro++* /usr/local/lib
-    #     ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
-    #     ln -s /usr/local/Cellar/hdf5/1.14.1/lib/lib* /usr/local/lib
-    #     ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/libcfitsio* /usr/local/lib
+    - name: cache dependencies
+      id: cache-deps
+      uses: john-shaffer/cache@main     # Need this to unpack the cache tar with sudo
+      env:
+        cache-name: cache-mcfost-dependencies
+      with:
+        path: |
+          /home/runner/work/include
+          /home/runner/work/lib
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
 
     - name: update gcc to v12 # Using gcc-11 will return a bug when compiling gas/wavelengths_gas.f90
       run: |
@@ -95,16 +78,12 @@ jobs:
     #        gcc --version
     #        gfortran --version
 
-    - name: prepare mcfost environment
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: prepare mcfost environment
       run: |
            cd lib
            ./install.sh
            cd ..
-
-    - name: check environment tree
-      run: |
-           sudo apt-get install tree
-           tree /home/runner/work
 
     - name: compile mcfost
       run: |

--- a/.github/workflows/build-gfortran-linux.yml
+++ b/.github/workflows/build-gfortran-linux.yml
@@ -55,6 +55,34 @@ jobs:
     # - name: install sprng2
     #   run: sudo apt-get install libsprng2
 
+    # - name: cache dependencies
+    #   id: cache-deps
+    #   uses: john-shaffer/cache@main     # Need this to unpack the cache tar with sudo
+    #   env:
+    #     cache-name: cache-mcfost-dependencies
+    #   with:
+    #     path: |
+    #       /usr/local/Cellar/gcc/13.1.0
+    #       /usr/local/Cellar/hdf5/1.14.1
+    #       /usr/local/Cellar/cfitsio/4.3.0
+    #       /usr/local/Cellar/voro-dev/0.4.6+
+    #       /usr/local/Cellar/sprng2/2.0
+    #     key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    #   # Restoring the brew installs from cache doesn't put files where mcfost expects
+    #   # Manually create symlinks so the compiler can find everything
+    # - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
+    #   name: add symbolic links if cache exists
+    #   run: |
+    #     ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
+    #     ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
+    #     ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
+    #     ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
+    #     ln -s /usr/local/Cellar/voro-dev/0.4.6+/lib/libvoro++* /usr/local/lib
+    #     ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
+    #     ln -s /usr/local/Cellar/hdf5/1.14.1/lib/lib* /usr/local/lib
+    #     ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/libcfitsio* /usr/local/lib
+
     - name: update gcc to v12 # Using gcc-11 will return a bug when compiling gas/wavelengths_gas.f90
       run: |
            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12
@@ -72,6 +100,11 @@ jobs:
            cd lib
            ./install.sh
            cd ..
+
+    - name: check environment tree
+      run: |
+           sudo apt-get install tree
+           tree /home/runner/work
 
     - name: compile mcfost
       run: |


### PR DESCRIPTION
Same as https://github.com/cpinte/mcfost/pull/63 but for the linux build script. Substantial reduction in build duration. Note again that the cache is automatically cleared every 7 days if not used.